### PR TITLE
fix links to source for C++ tutorial

### DIFF
--- a/docs/tutorials/cpp/session_1.md
+++ b/docs/tutorials/cpp/session_1.md
@@ -19,7 +19,7 @@
 
 ## C++ Types, Expressions, and Statements
 
-```{literalinclude} ../../../examples/cpp/00_types_expressions_statements.cpp
+```{literalinclude} ../../examples/cpp/00_types_expressions_statements.cpp
 ---
 language: c++
 linenos: true
@@ -28,7 +28,7 @@ linenos: true
 
 ## C++ Operators and Conditionals
 
-```{literalinclude} ../../../examples/cpp/01_operators_conditionals.cpp
+```{literalinclude} ../../examples/cpp/01_operators_conditionals.cpp
 ---
 language: c++
 linenos: true

--- a/docs/tutorials/cpp/session_2.md
+++ b/docs/tutorials/cpp/session_2.md
@@ -10,7 +10,7 @@
 
 `clang++ -std=c++17 -o 02_branching_loops 02_branching_loops.cpp`
 
-```{literalinclude} ../../../examples/cpp/02_branching_loops.cpp
+```{literalinclude} ../../examples/cpp/02_branching_loops.cpp
 ---
 language: c++
 linenos: true
@@ -19,7 +19,7 @@ linenos: true
 
 `clang++ -std=c++17 -o functions_references_pointers functions_references_pointers.cpp`
 
-```{literalinclude} ../../../examples/cpp/functions_references_pointers.cpp
+```{literalinclude} ../../examples/cpp/functions_references_pointers.cpp
 ---
 language: c++
 linenos: true

--- a/docs/tutorials/cpp/session_3.md
+++ b/docs/tutorials/cpp/session_3.md
@@ -10,7 +10,7 @@
 
 `c++ -std=c++17 -o functors_and_lamda_functions functors_and_lamda_functions.cpp
 
-```{literalinclude} ../../../examples/cpp/functors_and_lamda_functions.cpp
+```{literalinclude} ../../examples/cpp/functors_and_lamda_functions.cpp
 ---
 language: c++
 linenos: true

--- a/docs/tutorials/cpp/session_4.md
+++ b/docs/tutorials/cpp/session_4.md
@@ -10,21 +10,21 @@
 
 ### Simple Vector Class
 
-```{literalinclude} ../../../examples/cpp/classes/vector_class.hpp
+```{literalinclude} ../../examples/cpp/classes/vector_class.hpp
 ---
 language: c++
 linenos: true
 ---
 ```
 
-```{literalinclude} ../../../examples/cpp/classes/vector_class.cpp
+```{literalinclude} ../../examples/cpp/classes/vector_class.cpp
 ---
 language: c++
 linenos: true
 ---
 ```
 
-```{literalinclude} ../../../examples/cpp/classes/vector_test.cpp
+```{literalinclude} ../../examples/cpp/classes/vector_test.cpp
 ---
 language: c++
 linenos: true
@@ -33,21 +33,21 @@ linenos: true
 
 ### Class Inheritance
 
-```{literalinclude} ../../../examples/cpp/classes/simple_inheritance.hpp
+```{literalinclude} ../../examples/cpp/classes/simple_inheritance.hpp
 ---
 language: c++
 linenos: true
 ---
 ```
 
-```{literalinclude} ../../../examples/cpp/classes/simple_inheritance.hpp
+```{literalinclude} ../../examples/cpp/classes/simple_inheritance.hpp
 ---
 language: c++
 linenos: true
 ---
 ```
 
-```{literalinclude} ../../../examples/cpp/classes/inheritance_test.hpp
+```{literalinclude} ../../examples/cpp/classes/inheritance_test.hpp
 ---
 language: c++
 linenos: true
@@ -56,7 +56,7 @@ linenos: true
 
 ### Eigen Demo
 
-```{literalinclude} ../../../examples/cpp/classes/eigen_demo.cpp
+```{literalinclude} ../../examples/cpp/classes/eigen_demo.cpp
 ---
 language: c++
 linenos: true
@@ -65,7 +65,7 @@ linenos: true
 
 ### Armadillo Demo
 
-```{literalinclude} ../../../examples/cpp/armadillo/main.cpp
+```{literalinclude} ../../examples/cpp/armadillo/main.cpp
 ---
 language: c++
 linenos: true

--- a/docs/tutorials/cpp/session_5.md
+++ b/docs/tutorials/cpp/session_5.md
@@ -8,14 +8,14 @@
 
 ## C++ Templates
 
-```{literalinclude} ../../../examples/cpp/templates.hpp
+```{literalinclude} ../../examples/cpp/templates.hpp
 ---
 language: c++
 linenos: true
 ---
 ```
 
-```{literalinclude} ../../../examples/cpp/templates.cpp
+```{literalinclude} ../../examples/cpp/templates.cpp
 ---
 language: c++
 linenos: true


### PR DESCRIPTION
Fix relative paths to C++ sources.

NOTE: Pages still have references to material that appears to exist only on M2 (specifically, `/hpc/examples/workshops/hpc/session9_*.tgz`)