### PR TITLE
add a module for qchem 5.2.2.

### DIFF
--- a/modules/m3/applications/q-chem/5.2.2.lua
+++ b/modules/m3/applications/q-chem/5.2.2.lua
@@ -1,0 +1,5 @@
+whatis("Q-Chem")
+family("qchem")
+
+source_sh('bash', '/hpc/m3/apps/q-chem/5.2.2/qcenv.sh')
+


### PR DESCRIPTION
Temp fix so q-chem can be used while waiting for the license file updates