### PR TITLE
Add slurm to desktop container

### DIFF
--- a/containers/remote_desktop/desktop.def
+++ b/containers/remote_desktop/desktop.def
@@ -51,6 +51,7 @@ From: ubuntu:22.04
                tcl8.6 \
                tcl8.6-dev:amd64 \
                libtcl8.6:amd64 \
+               libmunge-dev \
                zsh \
                tcsh \
                ksh \
@@ -90,7 +91,10 @@ From: ubuntu:22.04
                make \
                wget \
                git \
-               strace
+               strace \
+               lsb \
+               libxm4 \
+               xsltproc
 
   # Configure default locale
   echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen

--- a/ood/combined_desktop/submit.yml.erb
+++ b/ood/combined_desktop/submit.yml.erb
@@ -27,7 +27,7 @@ batch_connect:
 
     %s  
     
-    export PATH=$/hpc/sys/apps/slurm/current/bin${PATH:+":$PATH"}"
+    export PATH="/hpc/sys/apps/slurm/current/bin${PATH:+":$PATH"}"
     CTRSCRIPT
     chmod +x container.sh
 

--- a/ood/combined_desktop/submit.yml.erb
+++ b/ood/combined_desktop/submit.yml.erb
@@ -26,14 +26,14 @@ batch_connect:
     #!/bin/bash
 
     %s  
-    
-    export PATH="/hpc/sys/apps/slurm/current/bin${PATH:+":$PATH"}"
     CTRSCRIPT
     chmod +x container.sh
 
     sed -e s/-nohttpd//g -i container.sh
 
     export APPTAINER_BINDPATH="$HOME,/run,/tmp,/hpc,$SCRATCH,$WORK,/cm/local/apps/slurm"
+
+    export SINGULARITYENV_PREPEND_PATH="/hpc/sys/apps/slurm/current/bin${SINGULARITYENV_PREPEND_PATH:+":$SINGULARITYENV_PREPEND_PATH"}"
     
     CONTAINER_SCRIPT=$(pwd)/container.sh
 

--- a/ood/combined_desktop/submit.yml.erb
+++ b/ood/combined_desktop/submit.yml.erb
@@ -26,12 +26,14 @@ batch_connect:
     #!/bin/bash
 
     %s  
+    
+    export PATH=$/hpc/sys/apps/slurm/current/bin${PATH:+":$PATH"}"
     CTRSCRIPT
     chmod +x container.sh
 
     sed -e s/-nohttpd//g -i container.sh
 
-    export APPTAINER_BINDPATH="$HOME,/run,/tmp,/hpc,$SCRATCH,$WORK"
+    export APPTAINER_BINDPATH="$HOME,/run,/tmp,/hpc,$SCRATCH,$WORK,/cm/local/apps/slurm"
     
     CONTAINER_SCRIPT=$(pwd)/container.sh
 


### PR DESCRIPTION
Adds abitility to call slurm functions from remote desktop (cannot submit jobs from remote desktop, just like inside all jobs)

Fixes issue with Ansys trying to use slurm commands in the background