### PR TITLE
Workshop queue

### DIFF
--- a/ood/combined_desktop/form.yml.erb
+++ b/ood/combined_desktop/form.yml.erb
@@ -1,3 +1,72 @@
+<%-
+require 'open3'
+
+# check queues
+class CheckQueues
+
+  @cache = ActiveSupport::Cache::FileStore.new("/users/#{User.new.name}/.cache/OpenOnDemand/", :expires_in => 1.minute)
+
+  def self.GetQueues()
+    begin
+      # get list of queues from sinfo
+      script = "/hpc/sys/apps/slurm/current/bin/sinfo --hide -ho '%R %l %c %m %G'"
+      o, status = Open3.capture2e(script)
+      tmp_output = o.split("\n")
+
+      output = []
+      tmp_output.each do |q|
+        params = q.gsub(/\s+/m, ' ').strip.split(" ")
+
+        # convert time to hours
+        hours = 0
+        tmp = params[1].split("-")
+        if tmp.count == 2
+          hours = hours + 24*tmp[0].to_i
+          hours = hours + tmp[1].split(":")[0].to_i
+        else
+          hours = hours + tmp[0].split(":")[0].to_i
+        end
+        params[1] = hours
+
+        # convert memory to GB (implicit floor division)
+        params[3] = params[3].to_i / 1024
+
+        # get number of gpus
+        if params[4] == "(null)"
+          params[4] = 0
+        else
+          params[4] = params[4].split(":")[-1]
+        end
+
+        # if HTC, set cores to 1
+        if params[0] == "htc"
+          params[2] = 1
+        end
+
+        # only keep queues with time limits <= 24 hours
+        # or highmem
+        if (hours < 25 || params[0] == "highmem")
+          # set the time limit to 12 hours or max queue time
+          params[1] = [params[1].to_i, 12].min
+          output.push(params) 
+        end
+      end
+      return output
+    end
+  end
+
+  def self.Queues
+    begin
+      @Queues = @cache.fetch("#{User.new.name}/queues", race_condition_ttl: 30.seconds) do
+        self.GetQueues()
+      end
+      return @Queues
+    end
+  end
+end
+
+-%>
+
 ---
 
 title: "Remote Desktop"
@@ -20,46 +89,23 @@ attributes:
     label: "Partition"
     widget: select
     help: |
-      Please select the SLURM partition to submit the job to.
+      Please select the [SLURM partition] to submit the job to.
+      [SLURM partition]: https://southernmethodistuniversity.github.io/hpc_docs/about/queues.html#m3-queues
     options:
-      - ["Development Queue (2 hour limit)", "dev",
-        data-max-bc-num-hours: 2,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 500,
-        data-set-bc-num-gpus: 0,
+    <%- CheckQueues.Queues.each do |q| -%>
+      - ["<%= q[0] %>", "<%= q[0] %>",
+        data-max-bc-num-hours: "<%= q[1] %>",
+        data-max-bc-num-cores: "<%= q[2] %>",
+        data-max-bc-num-memory: "<%= q[3] %>",
+        data-set-bc-num-gpus: "<%= q[4] %>",
+        <%- if q[4].to_i == 0 -%>
         data-hide-bc-num-gpus: true,
         data-show-desktop-os: true,
-        ]
-      - ["GPU Development Queue (2 hour limit)", "gpu-dev",
-        data-max-bc-num-hours: 2,
-        data-max-bc-num-cores: 36,
-        data-max-bc-num-memory: 734,
+        <%- else -%>
         data-show-bc-num-gpus: true,
+        <%- end -%>
         ]
-      - ["HTC Queue (12 hour limit, 1 core)", "htc",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 1,
-        data-max-bc-num-memory: 500,
-        data-set-bc-num-gpus: 0,
-        data-hide-bc-num-gpus: true,
-        data-show-desktop-os: true,
-        ]
-      - ["Standard Memory Queue (12 hour limit)", "standard-s",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 500,
-        data-set-bc-num-gpus: 0,
-        data-hide-bc-num-gpus: true,
-        data-show-desktop-os: true,
-        ]
-      - ["High Memory Queue (12 hour limit)", "highmem",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 2000,
-        data-set-bc-num-gpus: 0,
-        data-hide-bc-num-gpus: true,
-        data-show-desktop-os: true,
-        ]
+      <%- end -%>
   desktop_os:
     label: "Operating System"
     widget: select
@@ -69,19 +115,33 @@ attributes:
     options:
       - ["Ubuntu 22.04", "/hpc/m3/containers/remote_desktop/remote_desktop_1.1.sif",
         data-set-desktop-env: 'mate',
-        data-option-for-custom-queues-gpu-dev: false
+        <%- CheckQueues.Queues.each do |q| -%>
+          <%- if q[4].to_i == 0 -%>
+        <%= "data-option-for-custom-queues-" + q[0].strip + ": true," %>
+          <%- else -%>
+        <%= "data-option-for-custom-queues-" + q[0].strip + ": false," %>
+          <%- end -%>
+        <%- end -%>
         ]
       - ["Ubuntu 22.04, GPU enabled", "/hpc/m3/containers/remote_desktop/remote_desktop_1.1_gpu.sif",
         data-set-desktop-env: 'mate',
-        data-option-for-custom-queues-gpu-dev: true,
-        data-option-for-custom-queues-standard-s: false,
-        data-option-for-custom-queues-htc: false,
-        data-option-for-custom-queues-highmem: false,
-        data-option-for-custom-queues-dev: false,
+        <%- CheckQueues.Queues.each do |q| -%>
+          <%- if q[4].to_i == 0 -%>
+        <%= "data-option-for-custom-queues-" + q[0].strip + ": false," %>
+          <%- else -%>
+        <%= "data-option-for-custom-queues-" + q[0].strip + ": true," %>
+          <%- end -%>
+        <%- end -%>
         ]
       - ["AlmaLinux 8", "/hpc/m3/containers/remote_desktop/almalinux_remote_desktop_1.0.0.sif",
         data-set-desktop-env: 'xfce',
-        data-option-for-custom-queues-gpu-dev: false
+        <%- CheckQueues.Queues.each do |q| -%>
+          <%- if q[4].to_i == 0 -%>
+        <%= "data-option-for-custom-queues-" + q[0].strip + ": true," %>
+          <%- else -%>
+        <%= "data-option-for-custom-queues-" + q[0].strip + ": false," %>
+          <%- end -%>
+        <%- end -%>
         ]
   bc_vnc_idle: 2700
   bc_num_hours:

--- a/ood/jupyterlab/form.yml.erb
+++ b/ood/jupyterlab/form.yml.erb
@@ -317,7 +317,7 @@ class CustomEnvironments
 
 end
 
-# check for workshop queue
+# check queues
 class CheckQueues
  
   @cache = ActiveSupport::Cache::FileStore.new("/users/#{User.new.name}/.cache/OpenOnDemand/", :expires_in => 1.minute)

--- a/ood/jupyterlab/form.yml.erb
+++ b/ood/jupyterlab/form.yml.erb
@@ -405,7 +405,8 @@ attributes:
     label: "Partition"
     widget: select
     help: |
-      Please select the SLURM partition to submit the job to.
+      Please select the [SLURM partition] to submit the job to.
+      [SLURM partition]: https://southernmethodistuniversity.github.io/hpc_docs/about/queues.html#m3-queues
     options:
     <%- CheckQueues.Queues.each do |q| -%>
       - ["<%= q[0] %>", "<%= q[0] %>",

--- a/ood/jupyterlab/form.yml.erb
+++ b/ood/jupyterlab/form.yml.erb
@@ -325,9 +325,48 @@ class CheckQueues
   def self.GetQueues()
     begin
       # get list of queues from sinfo
-      script = "/hpc/sys/apps/slurm/current/bin/sinfo -ho '%R'"
+      script = "/hpc/sys/apps/slurm/current/bin/sinfo --hide -ho '%R %l %c %m %G'"
       o, status = Open3.capture2e(script)
-      output = o.split("\n")
+      tmp_output = o.split("\n")
+
+      output = []
+      tmp_output.each do |q|
+        params = q.gsub(/\s+/m, ' ').strip.split(" ")
+        
+        # convert time to hours
+        hours = 0
+        tmp = params[1].split("-")
+        if tmp.count == 2
+          hours = hours + 24*tmp[0].to_i
+          hours = hours + tmp[1].split(":")[0].to_i
+        else
+          hours = hours + tmp[0].split(":")[0].to_i
+        end
+        params[1] = hours
+        
+        # convert memory to GB (implicit floor division)
+        params[3] = params[3].to_i / 1024
+
+        # get number of gpus
+        if params[4] == "(null)"
+          params[4] = 0
+        else
+          params[4] = params[4].split(":")[-1]
+        end
+
+        # if HTC, set cores to 1
+        if params[0] == "htc"
+          params[2] = 1
+        end
+
+        # only keep queues with time limits <= 24 hours
+        # or highmem
+        if (hours < 25 || params[0] == "highmem")
+          # set the time limit to 12 hours or max queue time
+          params[1] = [params[1].to_i, 12].min
+          output.push(params) 
+        end
+      end
       return output
     end
   end
@@ -340,18 +379,7 @@ class CheckQueues
       return @Queues
     end
   end
-
-  def self.HasQueue(check_q)
-    @HasQueue = false
-    self.Queues.each do |q|
-       if (q == check_q)
-         @HasQueue = true
-       end
-    end 
-    return @HasQueue
-  end
 end
-
 
 -%>
 
@@ -379,49 +407,19 @@ attributes:
     help: |
       Please select the SLURM partition to submit the job to.
     options:
-      - ["Development Queue (2 hour limit)", "dev",
-        data-max-bc-num-hours: 2,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 500,
-        data-set-bc-num-gpus: 0,
+    <%- CheckQueues.Queues.each do |q| -%>
+      - ["<%= q[0] %>", "<%= q[0] %>",
+        data-max-bc-num-hours: "<%= q[1] %>",
+        data-max-bc-num-cores: "<%= q[2] %>",
+        data-max-bc-num-memory: "<%= q[3] %>",
+        data-set-bc-num-gpus: "<%= q[4] %>",
+        <%- if q[4].to_i == 0 -%>
         data-hide-bc-num-gpus: true,
-        ]
-      - ["GPU Development Queue (2 hour limit)", "gpu-dev",
-        data-max-bc-num-hours: 2,
-        data-max-bc-num-cores: 36,
-        data-max-bc-num-memory: 734,
+        <%- else -%>
         data-show-bc-num-gpus: true,
+        <%- end -%>
         ]
-      - ["HTC Queue (12 hour limit, 1 core)", "htc",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 1,
-        data-max-bc-num-memory: 500,
-        data-set-bc-num-gpus: 0,
-        data-hide-bc-num-gpus: true,
-        ]
-      - ["Standard Memory Queue (12 hour limit)", "standard-s",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 500,
-        data-set-bc-num-gpus: 0,
-        data-hide-bc-num-gpus: true,
-        ]
-      - ["High Memory Queue (12 hour limit)", "highmem",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 2000,
-        data-set-bc-num-gpus: 0,
-        data-hide-bc-num-gpus: true,
-        ]
-      <%- if CheckQueues.HasQueue("workshop") -%>
-      - ["Workshop Queue", "workshop",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 500,
-        data-set-bc-num-gpus: 0,
-        data-hide-bc-num-gpus: true,
-        ]
-      <%- end -%>
+    <%- end -%>
   python_version:
     label: "Select Python Environment"
     widget: select

--- a/ood/jupyterlab/form.yml.erb
+++ b/ood/jupyterlab/form.yml.erb
@@ -317,6 +317,41 @@ class CustomEnvironments
 
 end
 
+# check for workshop queue
+class CheckQueues
+ 
+  @cache = ActiveSupport::Cache::FileStore.new("/users/#{User.new.name}/.cache/OpenOnDemand/", :expires_in => 1.minute)
+
+  def self.GetQueues()
+    begin
+      # get list of queues from sinfo
+      script = "/hpc/sys/apps/slurm/current/bin/sinfo -ho '%R'"
+      o, status = Open3.capture2e(script)
+      output = o.split("\n")
+      return output
+    end
+  end
+  
+  def self.Queues
+    begin
+      @Queues = @cache.fetch("#{User.new.name}/queues", race_condition_ttl: 30.seconds) do
+        self.GetQueues()
+      end
+      return @Queues
+    end
+  end
+
+  def self.HasQueue(check_q)
+    @HasQueue = false
+    self.Queues.each do |q|
+       if (q == check_q)
+         @HasQueue = true
+       end
+    end 
+    return @HasQueue
+  end
+end
+
 
 -%>
 
@@ -378,6 +413,15 @@ attributes:
         data-set-bc-num-gpus: 0,
         data-hide-bc-num-gpus: true,
         ]
+      <%- if CheckQueues.HasQueue("workshop") -%>
+      - ["Workshop Queue", "workshop",
+        data-max-bc-num-hours: 12,
+        data-max-bc-num-cores: 128,
+        data-max-bc-num-memory: 500,
+        data-set-bc-num-gpus: 0,
+        data-hide-bc-num-gpus: true,
+        ]
+      <%- end -%>
   python_version:
     label: "Select Python Environment"
     widget: select

--- a/ood/rstudio/form.yml.erb
+++ b/ood/rstudio/form.yml.erb
@@ -1,3 +1,72 @@
+<%-
+require 'open3'
+
+# check queues
+class CheckQueues
+
+  @cache = ActiveSupport::Cache::FileStore.new("/users/#{User.new.name}/.cache/OpenOnDemand/", :expires_in => 1.minute)
+
+  def self.GetQueues()
+    begin
+      # get list of queues from sinfo
+      script = "/hpc/sys/apps/slurm/current/bin/sinfo --hide -ho '%R %l %c %m %G'"
+      o, status = Open3.capture2e(script)
+      tmp_output = o.split("\n")
+
+      output = []
+      tmp_output.each do |q|
+        params = q.gsub(/\s+/m, ' ').strip.split(" ")
+
+        # convert time to hours
+        hours = 0
+        tmp = params[1].split("-")
+        if tmp.count == 2
+          hours = hours + 24*tmp[0].to_i
+          hours = hours + tmp[1].split(":")[0].to_i
+        else
+          hours = hours + tmp[0].split(":")[0].to_i
+        end
+        params[1] = hours
+
+        # convert memory to GB (implicit floor division)
+        params[3] = params[3].to_i / 1024
+
+        # get number of gpus
+        if params[4] == "(null)"
+          params[4] = 0
+        else
+          params[4] = params[4].split(":")[-1]
+        end
+
+        # if HTC, set cores to 1
+        if params[0] == "htc"
+          params[2] = 1
+        end
+
+        # only keep queues with time limits <= 24 hours
+        # or highmem
+        if (hours < 25 || params[0] == "highmem")
+          # set the time limit to 12 hours or max queue time
+          params[1] = [params[1].to_i, 12].min
+          output.push(params) 
+        end
+      end
+      return output
+    end
+  end
+
+  def self.Queues
+    begin
+      @Queues = @cache.fetch("#{User.new.name}/queues", race_condition_ttl: 30.seconds) do
+        self.GetQueues()
+      end
+      return @Queues
+    end
+  end
+end
+
+-%>
+
 ---
 cluster: "m3cluster"
 form:
@@ -9,6 +78,7 @@ form:
   - rserver_timeout
   - bc_num_cores
   - bc_num_memory
+  - bc_num_gpus
 attributes:
   auto_accounts:
    help: |
@@ -35,28 +105,24 @@ attributes:
     label: "Partition"
     widget: select
     help: |
-      Please select the SLURM partition to submit the job to.
+      Please select the [SLURM partition] to submit the job to.
+      [SLURM partition]: https://southernmethodistuniversity.github.io/hpc_docs/about/queues.html#m3-queues
     options:
-      - ["Development Queue (2 hour limit)", "dev",
-        data-max-bc-num-hours: 2,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 500,
+    <%- CheckQueues.Queues.each do |q| -%>
+      <%- if q[4].to_i == 0 -%> #disable gpu queues
+      - ["<%= q[0] %>", "<%= q[0] %>",
+        data-max-bc-num-hours: "<%= q[1] %>",
+        data-max-bc-num-cores: "<%= q[2] %>",
+        data-max-bc-num-memory: "<%= q[3] %>",
+        data-set-bc-num-gpus: "<%= q[4] %>",
+        <%- if q[4].to_i == 0 -%>
+        data-hide-bc-num-gpus: true,
+        <%- else -%>
+        data-show-bc-num-gpus: true,
+        <%- end -%>
         ]
-      - ["HTC Queue (12 hour limit, 1 core)", "htc",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 1,
-        data-max-bc-num-memory: 500,
-        ]
-      - ["Standard Memory Queue (12 hour limit)", "standard-s",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 500,
-        ]
-      - ["High Memory Queue (12 hour limit)", "highmem",
-        data-max-bc-num-hours: 12,
-        data-max-bc-num-cores: 128,
-        data-max-bc-num-memory: 2000,
-        ]
+       <%- end -%>
+    <%- end -%>
   bc_num_hours:
     label: Time (Hours)
     help: |
@@ -93,3 +159,11 @@ attributes:
     min: 1
     step: 1
     value: 4
+  bc_num_gpus:
+    label: "Number of GPUs"
+    help: "Please select the number of GPUs for your job"
+    widget: number_field
+    max: 8
+    min: 0
+    step: 0
+    value: 1

--- a/ood/rstudio/submit.yml.erb
+++ b/ood/rstudio/submit.yml.erb
@@ -14,3 +14,7 @@ script:
     - "<%= bc_num_cores.blank? ? 1 : bc_num_cores.to_i %>"
     - "--mem"
     - "<%= bc_num_memory.blank? ? 6144 : bc_num_memory.to_i*1024 %>"
+    <%- if bc_num_gpus.to_i != 0 -%>
+    - "--gres"
+    - "gpu:<%= bc_num_gpus.blank? ? 0 : bc_num_gpus.to_i %>"
+    <%- end -%>


### PR DESCRIPTION
Auto-populate queues and limits from slurm. 

Calls `sinfo --hide -ho '%R %l %c %m %G'` in order to retrieve a list of queues `%R`, time limits `%l`, cpu cores `%c`, memory (in MB) `%m`, and the gres info `%G`

This should only include the queues an user has access to. The memory, core limits, and GPU limits on the forms are set according what is returned. The time limit is set to the max of 12 hours of the queue limit. Queues with time limits greater than 24 hours are excluded, with the exception of `highmem`. The core limit for `htc` is overridden and set to 1.

Queue names on form are now exactly the same as shown in `sinfo`

**Rstudio** -- added setup for GPU queues but disabled them. I don't believe the R container can use GPUs.
