### PR TITLE
Fix amber module

### DIFF
--- a/docs/examples/amber/amber_cpu_example.sbatch
+++ b/docs/examples/amber/amber_cpu_example.sbatch
@@ -4,11 +4,14 @@
 #SBATCH -p dev
 #SBATCH -N 1
 #SBATCH --ntasks-per-node=4
-#SBATCH --exclusive
 
 # Amber
 module purge
+module use ../../../modules/m3/applications/
 module load amber
+
+echo $(module list)
+echo $(which mpicc)
 
 # Program Command
 srun sander.MPI -O -o stdout -i alanine_md.in -c alanine_md.rst -p alanine_md.prmtop -r alanine_md_new.rst -x alanine_md_new.mdcrd

--- a/modules/m3/applications/amber/22.lua
+++ b/modules/m3/applications/amber/22.lua
@@ -4,9 +4,8 @@ load("gcc/11.2.0")
 load("openblas/0.3.21-s5husbk",
      "fftw/3.3.10-gz7qiki",
      "zlib/1.2.13-u7kx7ln",
-     "openmpi/4.1.6-a4ksrza",
      "cmake/3.24.3-2buptpk",
      "boost/1.80.0-l5cj6ju",
      "bzip2/1.0.8-ujseine")
 source_sh('bash', "/hpc/m3/apps/amber/amber22/amber.sh")
-
+load("openmpi/4.1.6-a4ksrza")

--- a/modules/m3/applications/amber/22.lua
+++ b/modules/m3/applications/amber/22.lua
@@ -4,7 +4,7 @@ load("gcc/11.2.0")
 load("openblas/0.3.21-s5husbk",
      "fftw/3.3.10-gz7qiki",
      "zlib/1.2.13-u7kx7ln",
-     "openmpi/4.1.4-7al4h2x",
+     "openmpi/4.1.6-a4ksrza",
      "cmake/3.24.3-2buptpk",
      "boost/1.80.0-l5cj6ju",
      "bzip2/1.0.8-ujseine")


### PR DESCRIPTION
Amber (MPI) is broken as a result of openmpi breaking with the slurm / pmix update.

Loading the newer, working, mpi module after Amber appears to work. Tested with [example in docs](../tree/main/docs/examples/amber/amber_cpu_example.sbatch)