### PR TITLE
Add slurm accounts to desktop

### DIFF
--- a/ood/combined_desktop/CheckAccounts.rb
+++ b/ood/combined_desktop/CheckAccounts.rb
@@ -1,0 +1,1 @@
+../common/CheckAccounts.rb

--- a/ood/combined_desktop/form.yml.erb
+++ b/ood/combined_desktop/form.yml.erb
@@ -3,6 +3,7 @@ require 'open3'
 
 # check queue help scripts
 require_relative "CheckQueues"
+require_relative "CheckAccounts"
 
 -%>
 
@@ -13,6 +14,9 @@ cluster: "m3cluster"
 submit: submit.yml.erb
 
 form:
+<%- if CheckAccounts.Accounts.length() > 1 -%>
+  - slurm_accounts
+<%- end -%>
   - custom_queues
   - desktop_os
   - desktop_env
@@ -24,6 +28,19 @@ form:
   - bc_num_gpus
 
 attributes:
+<%- if CheckAccounts.Accounts.length() > 1 -%>
+  slurm_accounts:
+   widget: select
+   label: "Slurm Account"
+   help: |
+     Select a Slurm account. By default all users have a  default "smu" account.
+     You may have other accounts, e.g. to access course specific material or
+     special allocations.
+   options:
+    <%- CheckAccounts.Accounts.each do |q| -%>
+    - [ "<%= q %>",  "<%= q %>" ]
+    <%- end -%>
+<%- end -%>
   custom_queues:
     label: "Partition"
     widget: select

--- a/ood/combined_desktop/submit.yml.erb
+++ b/ood/combined_desktop/submit.yml.erb
@@ -15,6 +15,10 @@ script:
     - "--gres"
     - "gpu:<%= bc_num_gpus.blank? ? 0 : bc_num_gpus.to_i %>"
     <%- end -%>
+    <%- if !slurm_accounts.blank? -%>
+    - "-A"
+    - "<%= slurm_accounts %>"
+    <%- end -%>
   template: "vnc"
 batch_connect:
   template: "vnc"

--- a/ood/combined_desktop/submit.yml.erb
+++ b/ood/combined_desktop/submit.yml.erb
@@ -15,7 +15,7 @@ script:
     - "--gres"
     - "gpu:<%= bc_num_gpus.blank? ? 0 : bc_num_gpus.to_i %>"
     <%- end -%>
-    <%- if !slurm_accounts.blank? -%>
+    <%- if defined?slurm_accounts -%>
     - "-A"
     - "<%= slurm_accounts %>"
     <%- end -%>


### PR DESCRIPTION
Amit setup a workshop account / queue for Tue's workshop. This allows the selection of an account on the remote desktop app.

Eric tested that he can still run jobs and does not see slurm account options since he does not have any non-default slurm accounts.