### PR TITLE
Remove JupyterLab from _toc.yml

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -62,8 +62,6 @@ parts:
     - file: tutorials/r/environments.md
     - file: tutorials/r/slurm.md
   - file: applications/vscode.md
-  - file: tutorials/navigating_jupyterlab.md
-    title: JupyterLab
   - file: applications/other_applications.md
     sections: 
     - file: examples/amber/index.md


### PR DESCRIPTION
Removed JupyterLab tutorial from the table of contents.